### PR TITLE
Fix missing GlassWeatherCard and widget Info.plist path

### DIFF
--- a/ClockWeatherApp/GlassWeatherCard.swift
+++ b/ClockWeatherApp/GlassWeatherCard.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct GlassWeatherCard: View {
+    @ObservedObject var weather: WeatherFetcher
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(weather.city).font(.caption)
+            Text(weather.condition).font(.caption2)
+            Text(weather.temperature).font(.title2).bold()
+        }
+        .padding(8)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/MyAppWidget/Info.plist
+++ b/MyAppWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add a simple `GlassWeatherCard` SwiftUI view
- provide missing `Info.plist` for MyAppWidget extension

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68500635bf248326bc10f57ee41adf93