### PR TITLE
Fix widget style and add flip clock animation

### DIFF
--- a/ClockWeatherApp/ContentView.swift
+++ b/ClockWeatherApp/ContentView.swift
@@ -42,7 +42,9 @@ func getCurrentTime() -> (hour: String, minute: String) {
 
 func requestLocation(weather: WeatherFetcher) {
     let manager = CLLocationManager()
-    manager.requestWhenInUseAuthorization()
+    if Bundle.main.object(forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription") != nil {
+        manager.requestWhenInUseAuthorization()
+    }
     if let location = manager.location {
         let coords = location.coordinate
         weather.fetchWeather(lat: coords.latitude, lon: coords.longitude)

--- a/ClockWeatherApp/FlipDigitView.swift
+++ b/ClockWeatherApp/FlipDigitView.swift
@@ -2,13 +2,19 @@
 import SwiftUI
 
 struct FlipDigitView: View {
+    /// The digit currently being displayed.
     let digit: String
 
+    /// The digit that was previously shown. Used for the flip animation.
+    @State private var previousDigit: String = ""
+    /// Rotation value used to create a simple flip effect.
+    @State private var rotation: Double = 0
+
     var body: some View {
-        Text(digit)
+        Text(previousDigit)
             .font(.system(size: 60, weight: .bold, design: .rounded))
             .frame(width: 80, height: 100)
-            .background(Color.white)
+            .background(.ultraThinMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .overlay(
                 Rectangle()
@@ -16,6 +22,21 @@ struct FlipDigitView: View {
                     .foregroundColor(.gray.opacity(0.4)),
                 alignment: .center
             )
+            .rotation3DEffect(.degrees(rotation), axis: (x: 1, y: 0, z: 0))
+            .onAppear { previousDigit = digit }
+            .onChange(of: digit) { newValue in
+                // Animate the digit flipping over when it changes.
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    rotation = -90
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    previousDigit = newValue
+                    rotation = 90
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        rotation = 0
+                    }
+                }
+            }
             .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
     }
 }

--- a/ClockWeatherApp/WeatherFetcher.swift
+++ b/ClockWeatherApp/WeatherFetcher.swift
@@ -24,20 +24,25 @@ class WeatherFetcher: ObservableObject {
         guard let url = URL(string: urlString) else { return }
 
         URLSession.shared.dataTask(with: url) { data, _, _ in
-            if let data = data {
-                if let decoded = try? JSONDecoder().decode(WeatherResponse.self, from: data) {
-                    DispatchQueue.main.async {
-                        let temp = "\(Int(decoded.current_weather.temperature))°"
-                        let desc = self.description(for: decoded.current_weather.weathercode)
-
-                        self.temperature = temp
-                        self.condition = desc
-
-                        self.sharedDefaults?.setValue(temp, forKey: "temperature")
-                        self.sharedDefaults?.setValue(desc, forKey: "condition")
-                        self.sharedDefaults?.setValue(Date(), forKey: "lastUpdated")
-                    }
+            guard let data = data,
+                  let decoded = try? JSONDecoder().decode(WeatherResponse.self, from: data) else {
+                DispatchQueue.main.async {
+                    self.temperature = "--"
+                    self.condition = "Unavailable"
                 }
+                return
+            }
+
+            DispatchQueue.main.async {
+                let temp = "\(Int(decoded.current_weather.temperature))°"
+                let desc = self.description(for: decoded.current_weather.weathercode)
+
+                self.temperature = temp
+                self.condition = desc
+
+                self.sharedDefaults?.setValue(temp, forKey: "temperature")
+                self.sharedDefaults?.setValue(desc, forKey: "condition")
+                self.sharedDefaults?.setValue(Date(), forKey: "lastUpdated")
             }
         }.resume()
 


### PR DESCRIPTION
## Summary
- flip clock digits animate on change
- handle missing location permission to avoid crashes
- show fallback weather status if API fails
- restyle widget with liquid glass background

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6850205cf4848326b8b2319c61ac3993