### PR TITLE
Fix onChange deprecation warnings

### DIFF
--- a/ClockWeatherApp/FlipDigitView.swift
+++ b/ClockWeatherApp/FlipDigitView.swift
@@ -24,7 +24,7 @@ struct FlipDigitView: View {
             )
             .rotation3DEffect(.degrees(rotation), axis: (x: 1, y: 0, z: 0))
             .onAppear { previousDigit = digit }
-            .onChange(of: digit) { newValue in
+            .onChange(of: digit) { _, newValue in
                 // Animate the digit flipping over when it changes.
                 withAnimation(.easeInOut(duration: 0.25)) {
                     rotation = -90

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -16,7 +16,7 @@ struct WidgetFlipDigitView: View {
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .rotation3DEffect(.degrees(rotation), axis: (x: 1, y: 0, z: 0))
             .onAppear { previousDigit = digit }
-            .onChange(of: digit) { newValue in
+            .onChange(of: digit) { _, newValue in
                 withAnimation(.easeInOut(duration: 0.25)) {
                     rotation = -90
                 }


### PR DESCRIPTION
## Summary
- update onChange closures in `FlipDigitView` and the widget to use the two-parameter closure form

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68502d036c88832694a49acaba258d98