### PR TITLE
Make widget background transparent

### DIFF
--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -102,7 +102,7 @@ struct ClockWeatherWidgetEntryView: View {
             }
         }
         .padding()
-        .containerBackground(.ultraThinMaterial, for: .widget)
+        .containerBackground(Color.clear, for: .widget)
     }
 }
 


### PR DESCRIPTION
## Summary
- make ClockWeatherWidget background fully clear so the system shows through

## Testing
- `xcodebuild test -project ClockWeatherApp.xcodeproj -scheme ClockWeatherApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502f9f418883269a683914d207652e