### PR TITLE
Enable manual location and unit preference

### DIFF
--- a/ClockWeatherApp.xcodeproj/project.pbxproj
+++ b/ClockWeatherApp.xcodeproj/project.pbxproj
@@ -521,8 +521,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Used to get local weather";
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -549,8 +550,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                               INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Used to get local weather";
+                               INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ClockWeatherApp/LocationManager.swift
+++ b/ClockWeatherApp/LocationManager.swift
@@ -1,0 +1,29 @@
+import Foundation
+import CoreLocation
+import Combine
+
+class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    @Published var location: CLLocation?
+    private let manager = CLLocationManager()
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        if manager.authorizationStatus == .notDetermined {
+            manager.requestWhenInUseAuthorization()
+        } else if manager.authorizationStatus == .authorizedWhenInUse || manager.authorizationStatus == .authorizedAlways {
+            manager.startUpdatingLocation()
+        }
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        if manager.authorizationStatus == .authorizedWhenInUse || manager.authorizationStatus == .authorizedAlways {
+            manager.startUpdatingLocation()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        location = locations.last
+    }
+}
+

--- a/ClockWeatherApp/SettingsView.swift
+++ b/ClockWeatherApp/SettingsView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("unit") private var unit: String = "fahrenheit"
+    @State private var cityName: String = ""
+    @ObservedObject var weather: WeatherFetcher
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Location")) {
+                    TextField("City", text: $cityName)
+                    Button("Update") {
+                        weather.updateCity(cityName)
+                    }
+                }
+
+                Section(header: Text("Units")) {
+                    Picker("Units", selection: $unit) {
+                        Text("Fahrenheit").tag("fahrenheit")
+                        Text("Celsius").tag("celsius")
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: unit) { _, _ in
+                        weather.unit = unit
+                        weather.refresh()
+                    }
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    @Environment(\.dismiss) private var dismiss
+}
+
+#Preview {
+    SettingsView(weather: WeatherFetcher())
+}
+


### PR DESCRIPTION
## Summary
- add location manager to request permission
- allow users to change location and units in new Settings view
- refresh weather when settings change or location updates
- save unit preference and coordinates for the widget
- update Info.plist settings for location permission

## Testing
- `swift --version`
- `xcodebuild -list -project ClockWeatherApp.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503046aa848326a6ae77fee28440af