### PR TITLE
Improve widget refresh and add 12‑hour clock option

### DIFF
--- a/ClockWeatherApp/ContentView.swift
+++ b/ClockWeatherApp/ContentView.swift
@@ -14,6 +14,8 @@ struct ContentView: View {
     @StateObject var weather = WeatherFetcher()
     @StateObject var locationManager = LocationManager()
     @State private var showSettings = false
+    @AppStorage("timeFormat", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    private var timeFormat: String = "24hr"
 
     var body: some View {
         VStack(spacing: 16) {
@@ -32,6 +34,9 @@ struct ContentView: View {
                 self.time = getCurrentTime()
             }
         }
+        .onChange(of: timeFormat) { _, _ in
+            self.time = getCurrentTime()
+        }
         .onChange(of: locationManager.location) { _, newValue in
             if let loc = newValue {
                 weather.fetchWeather(lat: loc.coordinate.latitude, lon: loc.coordinate.longitude)
@@ -44,8 +49,10 @@ struct ContentView: View {
 }
 
 func getCurrentTime() -> (hour: String, minute: String) {
+    let defaults = UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp")
+    let format = defaults?.string(forKey: "timeFormat") ?? "24hr"
     let formatter = DateFormatter()
-    formatter.dateFormat = "HH:mm"
+    formatter.dateFormat = format == "12hr" ? "hh:mm" : "HH:mm"
     let time = formatter.string(from: Date()).split(separator: ":")
     return (String(time[0]), String(time[1]))
 }

--- a/ClockWeatherApp/SettingsView.swift
+++ b/ClockWeatherApp/SettingsView.swift
@@ -1,21 +1,26 @@
 import SwiftUI
+import WidgetKit
 
 struct SettingsView: View {
-    @AppStorage("unit") private var unit: String = "fahrenheit"
+    @AppStorage("unit", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    private var unit: String = "fahrenheit"
+    @AppStorage("timeFormat", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    private var timeFormat: String = "24hr"
     @State private var cityName: String = ""
     @ObservedObject var weather: WeatherFetcher
 
     var body: some View {
         NavigationStack {
             Form {
-                Section(header: Text("Location")) {
+                Section("Location") {
                     TextField("City", text: $cityName)
+                        .textFieldStyle(.roundedBorder)
                     Button("Update") {
                         weather.updateCity(cityName)
                     }
                 }
 
-                Section(header: Text("Units")) {
+                Section("Units") {
                     Picker("Units", selection: $unit) {
                         Text("Fahrenheit").tag("fahrenheit")
                         Text("Celsius").tag("celsius")
@@ -26,8 +31,21 @@ struct SettingsView: View {
                         weather.refresh()
                     }
                 }
+
+                Section("Clock Format") {
+                    Picker("Clock Format", selection: $timeFormat) {
+                        Text("24 Hour").tag("24hr")
+                        Text("12 Hour").tag("12hr")
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: timeFormat) { _, _ in
+                        WidgetCenter.shared.reloadAllTimelines()
+                    }
+                }
             }
+            .formStyle(.grouped)
             .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }

--- a/ClockWeatherApp/WeatherFetcher.swift
+++ b/ClockWeatherApp/WeatherFetcher.swift
@@ -17,7 +17,8 @@ class WeatherFetcher: ObservableObject {
     @Published var temperature: String = "--"
     @Published var condition: String = "Loading..."
     @Published var city: String = "Locating..."
-    @AppStorage("unit") var unit: String = "fahrenheit"
+    @AppStorage("unit", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    var unit: String = "fahrenheit"
 
     private var lastCoordinates: CLLocationCoordinate2D?
 

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -1,5 +1,6 @@
 import WidgetKit
 import SwiftUI
+import Foundation
 
 /// Simplified flip digit view for the widget. This avoids needing to share
 /// sources between targets while still providing the flip animation.
@@ -78,8 +79,10 @@ struct ClockWeatherProvider: TimelineProvider {
     }
 
     func getCurrentTime() -> (hour: String, minute: String) {
+        let defaults = UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp")
+        let format = defaults?.string(forKey: "timeFormat") ?? "24hr"
         let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
+        formatter.dateFormat = format == "12hr" ? "hh:mm" : "HH:mm"
         let time = formatter.string(from: Date()).split(separator: ":")
         return (String(time[0]), String(time[1]))
     }


### PR DESCRIPTION
## Summary
- allow toggling 12/24‑hour time format in Settings
- persist unit and clock settings in the shared app group
- refresh displayed time when settings change
- update widget time formatter to respect the new setting
- clean up Settings form UI

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a1c350bc8326ac53363b242a4ab1