### PR TITLE
Add current location toggle

### DIFF
--- a/ClockWeatherApp/ContentView.swift
+++ b/ClockWeatherApp/ContentView.swift
@@ -16,6 +16,8 @@ struct ContentView: View {
     @State private var showSettings = false
     @AppStorage("timeFormat", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
     private var timeFormat: String = "24hr"
+    @AppStorage("locationMode", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    private var locationMode: String = "currentlocation"
 
     var body: some View {
         VStack(spacing: 16) {
@@ -38,7 +40,7 @@ struct ContentView: View {
             self.time = getCurrentTime()
         }
         .onChange(of: locationManager.location) { _, newValue in
-            if let loc = newValue {
+            if locationMode == "currentlocation", let loc = newValue {
                 weather.fetchWeather(lat: loc.coordinate.latitude, lon: loc.coordinate.longitude)
             }
         }

--- a/ClockWeatherApp/SettingsView.swift
+++ b/ClockWeatherApp/SettingsView.swift
@@ -6,6 +6,8 @@ struct SettingsView: View {
     private var unit: String = "fahrenheit"
     @AppStorage("timeFormat", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
     private var timeFormat: String = "24hr"
+    @AppStorage("locationMode", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    private var locationMode: String = "currentlocation"
     @State private var cityName: String = ""
     @ObservedObject var weather: WeatherFetcher
 
@@ -13,10 +15,18 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 Section("Location") {
-                    TextField("City", text: $cityName)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Update") {
-                        weather.updateCity(cityName)
+                    Picker("Source", selection: $locationMode) {
+                        Text("Current").tag("currentlocation")
+                        Text("Manual").tag("manual")
+                    }
+                    .pickerStyle(.segmented)
+
+                    if locationMode == "manual" {
+                        TextField("City", text: $cityName)
+                            .textFieldStyle(.roundedBorder)
+                        Button("Update") {
+                            weather.updateCity(cityName)
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- add `locationMode` setting to switch between device location and manual city
- display current/manual location picker in Settings
- update weather only when current location mode is enabled

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6851a4733a088326adf0dab6e568f916