### PR TITLE
Avoid early shared defaults access

### DIFF
--- a/ClockWeatherApp/ContentView.swift
+++ b/ClockWeatherApp/ContentView.swift
@@ -10,7 +10,7 @@ import CoreLocation
 import WidgetKit
 
 struct ContentView: View {
-    @State private var time = getCurrentTime()
+    @State private var time: (hour: String, minute: String) = ("--", "--")
     @StateObject var weather = WeatherFetcher()
     @StateObject var locationManager = LocationManager()
     @State private var showSettings = false
@@ -32,6 +32,7 @@ struct ContentView: View {
             Button("Settings") { showSettings = true }
         }
         .onAppear {
+            self.time = getCurrentTime()
             Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
                 self.time = getCurrentTime()
             }
@@ -51,8 +52,14 @@ struct ContentView: View {
 }
 
 func getCurrentTime() -> (hour: String, minute: String) {
-    let defaults = UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp")
-    let format = defaults?.string(forKey: "timeFormat") ?? "24hr"
+    var format = "24hr"
+    if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" {
+        if let defaults = UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp") {
+            format = defaults.string(forKey: "timeFormat") ?? "24hr"
+        } else {
+            print("❌ Couldn't load shared UserDefaults")
+        }
+    }
     let formatter = DateFormatter()
     formatter.dateFormat = format == "12hr" ? "hh:mm" : "HH:mm"
     let time = formatter.string(from: Date()).split(separator: ":")

--- a/ClockWeatherApp/WeatherFetcher.swift
+++ b/ClockWeatherApp/WeatherFetcher.swift
@@ -22,7 +22,10 @@ class WeatherFetcher: ObservableObject {
 
     private var lastCoordinates: CLLocationCoordinate2D?
 
-    let sharedDefaults = UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp")
+    private func sharedDefaults() -> UserDefaults? {
+        guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return nil }
+        return UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp")
+    }
 
     func fetchWeather(lat: Double, lon: Double) {
         lastCoordinates = CLLocationCoordinate2D(latitude: lat, longitude: lon)
@@ -47,12 +50,13 @@ class WeatherFetcher: ObservableObject {
                 self.temperature = temp
                 self.condition = desc
 
-                self.sharedDefaults?.setValue(temp, forKey: "temperature")
-                self.sharedDefaults?.setValue(desc, forKey: "condition")
-                self.sharedDefaults?.setValue(self.unit, forKey: "unit")
-                self.sharedDefaults?.setValue(self.lastCoordinates?.latitude, forKey: "lat")
-                self.sharedDefaults?.setValue(self.lastCoordinates?.longitude, forKey: "lon")
-                self.sharedDefaults?.setValue(Date(), forKey: "lastUpdated")
+                let defaults = self.sharedDefaults()
+                defaults?.setValue(temp, forKey: "temperature")
+                defaults?.setValue(desc, forKey: "condition")
+                defaults?.setValue(self.unit, forKey: "unit")
+                defaults?.setValue(self.lastCoordinates?.latitude, forKey: "lat")
+                defaults?.setValue(self.lastCoordinates?.longitude, forKey: "lon")
+                defaults?.setValue(Date(), forKey: "lastUpdated")
                 WidgetCenter.shared.reloadAllTimelines()
             }
         }.resume()
@@ -62,7 +66,7 @@ class WeatherFetcher: ObservableObject {
             if let city = placemarks?.first?.locality {
                 DispatchQueue.main.async {
                     self.city = city
-                    self.sharedDefaults?.setValue(city, forKey: "city")
+                    self.sharedDefaults()?.setValue(city, forKey: "city")
                 }
             }
         }

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -42,7 +42,11 @@ struct ClockWeatherEntry: TimelineEntry {
 }
 
 struct ClockWeatherProvider: TimelineProvider {
-    let sharedDefaults = UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp")
+
+    private func sharedDefaults() -> UserDefaults? {
+        guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return nil }
+        return UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp")
+    }
 
     func placeholder(in context: Context) -> ClockWeatherEntry {
         let time = getCurrentTime()
@@ -62,9 +66,10 @@ struct ClockWeatherProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<ClockWeatherEntry>) -> Void) {
         let time = getCurrentTime()
-        let temp = sharedDefaults?.string(forKey: "temperature") ?? "--°"
-        let cond = sharedDefaults?.string(forKey: "condition") ?? "Updating..."
-        let city = sharedDefaults?.string(forKey: "city") ?? "Location..."
+        let defaults = sharedDefaults()
+        let temp = defaults?.string(forKey: "temperature") ?? "--°"
+        let cond = defaults?.string(forKey: "condition") ?? "Updating..."
+        let city = defaults?.string(forKey: "city") ?? "Location..."
 
         let entry = ClockWeatherEntry(
             date: Date(),
@@ -79,7 +84,7 @@ struct ClockWeatherProvider: TimelineProvider {
     }
 
     func getCurrentTime() -> (hour: String, minute: String) {
-        let defaults = UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp")
+        let defaults = sharedDefaults()
         let format = defaults?.string(forKey: "timeFormat") ?? "24hr"
         let formatter = DateFormatter()
         formatter.dateFormat = format == "12hr" ? "hh:mm" : "HH:mm"


### PR DESCRIPTION
## Summary
- prevent early initialization of shared UserDefaults
- lazy load defaults only after the view appears
- guard against access during SwiftUI previews

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6851b65da0bc8326b4c776e6bbb03496