### PR TITLE
Fix UserDefaults suite name and duplicate ForEach IDs

### DIFF
--- a/ClockWeatherApp/ContentView.swift
+++ b/ClockWeatherApp/ContentView.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
     @State private var showSettings = false
     @AppStorage("timeFormat", store: UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp"))
     private var timeFormat: String = "24hr"
-    @AppStorage("locationMode", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    @AppStorage("locationMode", store: UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp"))
     private var locationMode: String = "currentlocation"
     @AppStorage("fontName", store: UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp"))
     private var fontName: String = UIFont.systemFont(ofSize: 17).familyName

--- a/ClockWeatherApp/FlipClockView.swift
+++ b/ClockWeatherApp/FlipClockView.swift
@@ -17,8 +17,8 @@ struct FlipClockView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            ForEach(Array(currentTime.hour), id: \.self) {
-                FlipDigitView(digit: String($0), fontName: fontName)
+            ForEach(Array(currentTime.hour.enumerated()), id: \.offset) { _, ch in
+                FlipDigitView(digit: String(ch), fontName: fontName)
             }
 
             Text(":")
@@ -26,8 +26,8 @@ struct FlipClockView: View {
                 .foregroundColor(.white)
                 .offset(y: -10)
 
-            ForEach(Array(currentTime.minute), id: \.self) {
-                FlipDigitView(digit: String($0), fontName: fontName)
+            ForEach(Array(currentTime.minute.enumerated()), id: \.offset) { _, ch in
+                FlipDigitView(digit: String(ch), fontName: fontName)
             }
         }
         .onAppear {

--- a/ClockWeatherApp/SettingsView.swift
+++ b/ClockWeatherApp/SettingsView.swift
@@ -7,7 +7,7 @@ struct SettingsView: View {
     private var unit: String = "fahrenheit"
     @AppStorage("timeFormat", store: UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp"))
     private var timeFormat: String = "24hr"
-    @AppStorage("locationMode", store: UserDefaults(suiteName: "group.com.yourcompany.ClockWeatherApp"))
+    @AppStorage("locationMode", store: UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp"))
     private var locationMode: String = "currentlocation"
     @AppStorage("fontName", store: UserDefaults(suiteName: "group.com.markmayne.ClockWeatherApp"))
     private var fontName: String = UIFont.systemFont(ofSize: 17).familyName

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -159,7 +159,8 @@ struct ClockWeatherWidgetEntryView: View {
     var body: some View {
         VStack(spacing: 12) {
             HStack(spacing: 6) {
-                ForEach(Array(entry.hour.map { String($0) }), id: \.self) { digit in
+                ForEach(Array(entry.hour.enumerated()), id: \.offset) { _, ch in
+                    let digit = String(ch)
                     WidgetFlipDigitView(digit: digit, fontName: entry.fontName)
                 }
 
@@ -168,7 +169,8 @@ struct ClockWeatherWidgetEntryView: View {
                     .foregroundStyle(.white)
                     .offset(y: -8)
 
-                ForEach(Array(entry.minute.map { String($0) }), id: \.self) { digit in
+                ForEach(Array(entry.minute.enumerated()), id: \.offset) { _, ch in
+                    let digit = String(ch)
                     WidgetFlipDigitView(digit: digit, fontName: entry.fontName)
                 }
             }


### PR DESCRIPTION
## Summary
- ensure shared UserDefaults suite uses the correct app group
- avoid duplicate IDs in clock digit `ForEach` loops by using `.enumerated()`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project ClockWeatherApp.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685232ee010483268b3a7dde82f1f0fa