### PR TITLE
Fix widget digit view compile issues

### DIFF
--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -38,16 +38,24 @@ struct WidgetSingleDigitView: View {
 
 /// Flip digit view used by the widget.
 struct WidgetFlipDigitView: View {
-    VStack(spacing: 0) {
-        ZStack {
-            WidgetSingleDigitView(text: digit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom)
-            WidgetSingleDigitView(text: previousDigit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom)
-                .rotation3DEffect(.degrees(animateTop ? -90 : 0),
-                                  axis: (x: 1, y: 0, z: 0),
-                                  anchor: .bottom,
-                                  perspective: 0.5)
-        }
-        .clipped()
+    let digit: String
+    let fontName: String
+
+    @State private var previousDigit: String = ""
+    @State private var animateTop = false
+    @State private var animateBottom = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                WidgetSingleDigitView(text: digit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom)
+                WidgetSingleDigitView(text: previousDigit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom)
+                    .rotation3DEffect(.degrees(animateTop ? -90 : 0),
+                                      axis: (x: 1, y: 0, z: 0),
+                                      anchor: .bottom,
+                                      perspective: 0.5)
+            }
+            .clipped()
 
         Rectangle()
             .fill(Color.gray.opacity(0.4))
@@ -79,6 +87,10 @@ struct WidgetFlipDigitView: View {
         }
     }
 }
+
+}
+
+
 
 struct ClockWeatherEntry: TimelineEntry {
     let date: Date


### PR DESCRIPTION
## Summary
- implement missing state and body in `WidgetFlipDigitView`
- ensure struct closes correctly

## Testing
- `swiftc --version`
- `swiftc -typecheck ClockWeatherWidget/ClockWeatherWidget.swift` *(fails: no such module 'WidgetKit')*

------
https://chatgpt.com/codex/tasks/task_e_6852393563308326a4b24ac737f00525