### PR TITLE
Modify flip clock layout

### DIFF
--- a/ClockWeatherApp/FlipClockView.swift
+++ b/ClockWeatherApp/FlipClockView.swift
@@ -17,18 +17,8 @@ struct FlipClockView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            ForEach(Array(currentTime.hour.enumerated()), id: \.offset) { _, ch in
-                FlipDigitView(digit: String(ch), fontName: fontName)
-            }
-
-            Text(":")
-                .font(.system(size: 50, weight: .bold, design: .monospaced))
-                .foregroundColor(.white)
-                .offset(y: -10)
-
-            ForEach(Array(currentTime.minute.enumerated()), id: \.offset) { _, ch in
-                FlipDigitView(digit: String(ch), fontName: fontName)
-            }
+            FlipDigitView(digit: currentTime.hour, fontName: fontName)
+            FlipDigitView(digit: currentTime.minute, fontName: fontName)
         }
         .onAppear {
             updateTime()

--- a/ClockWeatherApp/SingleDigitView.swift
+++ b/ClockWeatherApp/SingleDigitView.swift
@@ -13,10 +13,11 @@ struct SingleDigitView: View {
     let type: FlipType
 
     var body: some View {
+        let width = CGFloat(40 * max(1, text.count))
         Text(text)
             .font(.custom(fontName, size: 60))
             .foregroundColor(.white)
-            .frame(width: 40, height: 40, alignment: type.alignment)
+            .frame(width: width, height: 40, alignment: type.alignment)
             .padding(type.padding, -8)
             .clipped()
             .background(Color.black)

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -10,13 +10,14 @@ struct WidgetSingleDigitView: View {
     let type: FlipType
 
     var body: some View {
+        let width = CGFloat(40 * max(1, text.count))
         Text(text)
             .font(.custom(fontName, size: 60))
-            .foregroundColor(.white)
-            .frame(width: 40, height: 40, alignment: type.alignment)
+            .foregroundColor(.black)
+            .frame(width: width, height: 40, alignment: type.alignment)
             .padding(type.padding, -8)
             .clipped()
-            .background(Color.black)
+            .background(Color.white)
             .cornerRadius(4)
             .padding(type.padding, -4)
     }
@@ -163,20 +164,8 @@ struct ClockWeatherWidgetEntryView: View {
     var body: some View {
         VStack(spacing: 12) {
             HStack(spacing: 8) {
-                ForEach(Array(entry.hour.enumerated()), id: \.offset) { _, ch in
-                    let digit = String(ch)
-                    WidgetFlipDigitView(digit: digit, fontName: entry.fontName)
-                }
-
-                Text(":")
-                    .font(.system(size: 50, weight: .bold, design: .monospaced))
-                    .foregroundStyle(.black)
-                    .offset(y: -10)
-
-                ForEach(Array(entry.minute.enumerated()), id: \.offset) { _, ch in
-                    let digit = String(ch)
-                    WidgetFlipDigitView(digit: digit, fontName: entry.fontName)
-                }
+                WidgetFlipDigitView(digit: entry.hour, fontName: entry.fontName)
+                WidgetFlipDigitView(digit: entry.minute, fontName: entry.fontName)
             }
             .frame(height: 120)
 


### PR DESCRIPTION
## Summary
- remove colon separators and use one card per hour and minute
- support multi-character cards
- style widget digits with black text and white background

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68523d55df8483269db6f85a7f0d3eac