### PR TITLE
Fix font alignment and smoother font picker

### DIFF
--- a/ClockWeatherApp/SettingsView.swift
+++ b/ClockWeatherApp/SettingsView.swift
@@ -62,6 +62,7 @@ struct SettingsView: View {
                             Text(name).font(.custom(name, size: 16)).tag(name)
                         }
                     }
+                    .pickerStyle(.navigationLink)
                     .onChange(of: fontName) { _, _ in
                         WidgetCenter.shared.reloadAllTimelines()
                     }

--- a/ClockWeatherApp/SingleDigitView.swift
+++ b/ClockWeatherApp/SingleDigitView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct SingleDigitView: View {
     let text: String
@@ -14,8 +15,13 @@ struct SingleDigitView: View {
 
     var body: some View {
         let width = CGFloat(40 * max(1, text.count))
+        let fontSize: CGFloat = 60
+        let font = UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
+        let sample = ("8" as NSString).size(withAttributes: [.font: font])
+        let offset = (40 - sample.height) / 2
         Text(text)
-            .font(.custom(fontName, size: 60))
+            .font(.custom(fontName, size: fontSize))
+            .offset(y: offset)
             .foregroundColor(.white)
             .frame(width: width, height: 40, alignment: type.alignment)
             .padding(type.padding, -8)

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -11,8 +11,13 @@ struct WidgetSingleDigitView: View {
 
     var body: some View {
         let width = CGFloat(40 * max(1, text.count))
+        let fontSize: CGFloat = 60
+        let font = UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
+        let sample = ("8" as NSString).size(withAttributes: [.font: font])
+        let offset = (40 - sample.height) / 2
         Text(text)
-            .font(.custom(fontName, size: 60))
+            .font(.custom(fontName, size: fontSize))
+            .offset(y: offset)
             .foregroundColor(.black)
             .frame(width: width, height: 40, alignment: type.alignment)
             .padding(type.padding, -8)


### PR DESCRIPTION
## Summary
- adjust SingleDigitView alignment using font metrics
- mirror the same adjustment in widget digit view
- use navigationLink picker style for font list to stop scrolling jitter

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68524310d98c8326a00a1a9d562c936b