### PR TITLE
Apply rounded corners to flip cards

### DIFF
--- a/ClockWeatherApp/SingleDigitView.swift
+++ b/ClockWeatherApp/SingleDigitView.swift
@@ -27,7 +27,7 @@ struct SingleDigitView: View {
             .padding(type.padding, -8)
             .clipped()
             .background(Color.black)
-            .cornerRadius(4)
+            .cornerRadius(8)
             .padding(type.padding, -4)
     }
 

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -23,7 +23,7 @@ struct WidgetSingleDigitView: View {
             .padding(type.padding, -8)
             .clipped()
             .background(Color.white)
-            .cornerRadius(4)
+            .cornerRadius(8)
             .padding(type.padding, -4)
     }
 


### PR DESCRIPTION
## Summary
- round corners of digit flip cards in the main app
- apply matching corner radius in widget digit cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852a9267e34832696b5297dc2f5f9fe