### PR TITLE
Fix alignment for digit halves

### DIFF
--- a/ClockWeatherApp/SingleDigitView.swift
+++ b/ClockWeatherApp/SingleDigitView.swift
@@ -40,7 +40,7 @@ struct SingleDigitView: View {
         }
 
         var alignment: Alignment {
-            self == .top ? .bottom : .top
+            self == .top ? .top : .bottom
         }
     }
 }

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -36,7 +36,7 @@ struct WidgetSingleDigitView: View {
         }
 
         var alignment: Alignment {
-            self == .top ? .bottom : .top
+            self == .top ? .top : .bottom
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix alignment for top and bottom halves of the digits so top half shows correctly

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852aa5d55f08326a17f65efa64f4000