### PR TITLE
Improve flip clock scaling and add large widget

### DIFF
--- a/ClockWeatherApp/ContentView.swift
+++ b/ClockWeatherApp/ContentView.swift
@@ -25,8 +25,7 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 16) {
             HStack(spacing: 8) {
-                FlipClockView(fontName: fontName, timeFormat: timeFormat)
-                    .frame(height: 120)
+                FlipClockView(fontName: fontName, timeFormat: timeFormat, digitHeight: 80)
             }
 
             GlassWeatherCard(weather: weather)

--- a/ClockWeatherApp/FlipClockView.swift
+++ b/ClockWeatherApp/FlipClockView.swift
@@ -12,14 +12,15 @@ struct FlipClockView: View {
     @State private var currentTime: (hour: String, minute: String) = ("--", "--")
     let fontName: String
     let timeFormat: String
+    var digitHeight: CGFloat = 40
 
     // Update every second so the minute flips exactly when the system clock changes
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
         HStack(spacing: 8) {
-            FlipDigitView(digit: currentTime.hour, fontName: fontName)
-            FlipDigitView(digit: currentTime.minute, fontName: fontName)
+            FlipDigitView(digit: currentTime.hour, fontName: fontName, height: digitHeight)
+            FlipDigitView(digit: currentTime.minute, fontName: fontName, height: digitHeight)
         }
         .onAppear {
             updateTime()

--- a/ClockWeatherApp/FlipDigitView.swift
+++ b/ClockWeatherApp/FlipDigitView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FlipDigitView: View {
     let digit: String
     let fontName: String
+    var height: CGFloat = 40
 
     @State private var previousDigit: String = ""
     @State private var animateTop = false
@@ -11,8 +12,8 @@ struct FlipDigitView: View {
     var body: some View {
         VStack(spacing: 0) {
             ZStack {
-                SingleDigitView(text: digit, fontName: fontName, type: SingleDigitView.FlipType.top)
-                SingleDigitView(text: previousDigit, fontName: fontName, type: SingleDigitView.FlipType.top)
+                SingleDigitView(text: digit, fontName: fontName, type: SingleDigitView.FlipType.top, height: height)
+                SingleDigitView(text: previousDigit, fontName: fontName, type: SingleDigitView.FlipType.top, height: height)
                     .rotation3DEffect(.degrees(animateTop ? -90 : 0),
                                       axis: (x: 1, y: 0, z: 0),
                                       anchor: .bottom,
@@ -25,8 +26,8 @@ struct FlipDigitView: View {
                 .frame(height: 1)
 
             ZStack {
-                SingleDigitView(text: previousDigit, fontName: fontName, type: SingleDigitView.FlipType.bottom)
-                SingleDigitView(text: digit, fontName: fontName, type: SingleDigitView.FlipType.bottom)
+                SingleDigitView(text: previousDigit, fontName: fontName, type: SingleDigitView.FlipType.bottom, height: height)
+                SingleDigitView(text: digit, fontName: fontName, type: SingleDigitView.FlipType.bottom, height: height)
                     .rotation3DEffect(.degrees(animateBottom ? 0 : 90),
                                       axis: (x: 1, y: 0, z: 0),
                                       anchor: .top,

--- a/ClockWeatherApp/SingleDigitView.swift
+++ b/ClockWeatherApp/SingleDigitView.swift
@@ -12,23 +12,24 @@ struct SingleDigitView: View {
     let text: String
     let fontName: String
     let type: FlipType
+    var height: CGFloat = 40
 
     var body: some View {
-        let width = CGFloat(40 * max(1, text.count))
-        let fontSize: CGFloat = 60
+        let width = CGFloat(height * max(1, text.count))
+        let fontSize: CGFloat = height * 1.5
         let font = UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
         let sample = ("8" as NSString).size(withAttributes: [.font: font])
-        let offset = (40 - sample.height) / 2
+        let offset = (height - sample.height) / 2
         Text(text)
             .font(.custom(fontName, size: fontSize))
             .offset(y: offset)
             .foregroundColor(.white)
-            .frame(width: width, height: 40, alignment: type.alignment)
-            .padding(type.padding, -8)
+            .frame(width: width, height: height, alignment: type.alignment)
+            .padding(type.padding, -height / 5)
             .clipped()
             .background(Color.black)
-            .cornerRadius(8)
-            .padding(type.padding, -4)
+            .cornerRadius(height / 5)
+            .padding(type.padding, -height / 10)
     }
 
     enum FlipType {

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -8,23 +8,24 @@ struct WidgetSingleDigitView: View {
     let text: String
     let fontName: String
     let type: FlipType
+    var height: CGFloat = 40
 
     var body: some View {
-        let width = CGFloat(40 * max(1, text.count))
-        let fontSize: CGFloat = 60
+        let width = CGFloat(height * max(1, text.count))
+        let fontSize: CGFloat = height * 1.5
         let font = UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
         let sample = ("8" as NSString).size(withAttributes: [.font: font])
-        let offset = (40 - sample.height) / 2
+        let offset = (height - sample.height) / 2
         Text(text)
             .font(.custom(fontName, size: fontSize))
             .offset(y: offset)
             .foregroundColor(.black)
-            .frame(width: width, height: 40, alignment: type.alignment)
-            .padding(type.padding, -8)
+            .frame(width: width, height: height, alignment: type.alignment)
+            .padding(type.padding, -height / 5)
             .clipped()
             .background(Color.white)
-            .cornerRadius(8)
-            .padding(type.padding, -4)
+            .cornerRadius(height / 5)
+            .padding(type.padding, -height / 10)
     }
 
     enum FlipType {
@@ -46,6 +47,7 @@ struct WidgetSingleDigitView: View {
 struct WidgetFlipDigitView: View {
     let digit: String
     let fontName: String
+    var height: CGFloat = 40
 
     @State private var previousDigit: String = ""
     @State private var animateTop = false
@@ -54,8 +56,8 @@ struct WidgetFlipDigitView: View {
     var body: some View {
         VStack(spacing: 0) {
             ZStack {
-                WidgetSingleDigitView(text: digit, fontName: fontName, type: WidgetSingleDigitView.FlipType.top)
-                WidgetSingleDigitView(text: previousDigit, fontName: fontName, type: WidgetSingleDigitView.FlipType.top)
+                WidgetSingleDigitView(text: digit, fontName: fontName, type: WidgetSingleDigitView.FlipType.top, height: height)
+                WidgetSingleDigitView(text: previousDigit, fontName: fontName, type: WidgetSingleDigitView.FlipType.top, height: height)
                     .rotation3DEffect(.degrees(animateTop ? -90 : 0),
                                       axis: (x: 1, y: 0, z: 0),
                                       anchor: .bottom,
@@ -68,8 +70,8 @@ struct WidgetFlipDigitView: View {
             .frame(height: 1)
 
         ZStack {
-            WidgetSingleDigitView(text: previousDigit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom)
-            WidgetSingleDigitView(text: digit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom)
+            WidgetSingleDigitView(text: previousDigit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom, height: height)
+            WidgetSingleDigitView(text: digit, fontName: fontName, type: WidgetSingleDigitView.FlipType.bottom, height: height)
                 .rotation3DEffect(.degrees(animateBottom ? 0 : 90),
                                   axis: (x: 1, y: 0, z: 0),
                                   anchor: .top,
@@ -220,15 +222,25 @@ struct ClockWeatherProvider: TimelineProvider {
 }
 
 struct ClockWeatherWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var family
     var entry: ClockWeatherEntry
 
     var body: some View {
+        let digitHeight: CGFloat = {
+            switch family {
+            case .systemLarge, .systemExtraLarge:
+                return 80
+            default:
+                return 40
+            }
+        }()
+
         VStack(spacing: 12) {
             HStack(spacing: 8) {
-                WidgetFlipDigitView(digit: entry.hour, fontName: entry.fontName)
-                WidgetFlipDigitView(digit: entry.minute, fontName: entry.fontName)
+                WidgetFlipDigitView(digit: entry.hour, fontName: entry.fontName, height: digitHeight)
+                WidgetFlipDigitView(digit: entry.minute, fontName: entry.fontName, height: digitHeight)
             }
-            .frame(height: 100)
+            .frame(height: digitHeight * 2)
 
             HStack {
                 VStack(alignment: .leading) {
@@ -278,6 +290,6 @@ struct ClockWeatherWidget: Widget {
         }
         .configurationDisplayName("Flip Clock + Weather")
         .description("See the current time and weather at a glance.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge, .systemExtraLarge])
     }
 }


### PR DESCRIPTION
## Summary
- add height parameter to flip digit components so sizes can scale
- enlarge flip clock display in the main app
- support larger widget families and scale digits accordingly

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852ab8f50f4832695768aabf6bac7ad