### PR TITLE
Fix CGFloat conversion in widget

### DIFF
--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -11,7 +11,7 @@ struct WidgetSingleDigitView: View {
     var height: CGFloat = 40
 
     var body: some View {
-        let width = CGFloat(height * max(1, text.count))
+        let width = height * CGFloat(max(1, text.count))
         let fontSize: CGFloat = height * 1.5
         let font = UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
         let sample = ("8" as NSString).size(withAttributes: [.font: font])


### PR DESCRIPTION
## Summary
- fix `WidgetSingleDigitView` width calculation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852acb786ec8326be71d3eea6f5b03f