### PR TITLE
Improve widget layout and digit halves

### DIFF
--- a/ClockWeatherApp/DigitHalfView.swift
+++ b/ClockWeatherApp/DigitHalfView.swift
@@ -10,6 +10,8 @@ struct DigitHalfView: View {
     let digit: String
     let fontName: String
     let clipTop: Bool
+    var textColor: Color = .white
+    var backgroundColor: Color = .black
 
     var body: some View {
         GeometryReader { geo in
@@ -20,8 +22,8 @@ struct DigitHalfView: View {
                 Text(digit)
                     .font(.custom(fontName, size: size.height * 1.5))
                     .frame(width: size.width, height: size.height)
-                    .foregroundStyle(.white)
-                    .background(Color.black)
+                    .foregroundStyle(textColor)
+                    .background(backgroundColor)
                     .lineLimit(1)
                     .minimumScaleFactor(0.1)
                     .clipped()

--- a/ClockWeatherApp/SingleDigitView.swift
+++ b/ClockWeatherApp/SingleDigitView.swift
@@ -16,17 +16,8 @@ struct SingleDigitView: View {
 
     var body: some View {
         let width = CGFloat(height * max(1, text.count))
-        let fontSize: CGFloat = height * 1.5
-        let font = UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
-        let sample = ("8" as NSString).size(withAttributes: [.font: font])
-        let offset = (height - sample.height) / 2
-        Text(text)
-            .font(.custom(fontName, size: fontSize))
-            .offset(y: offset)
-            .foregroundColor(.white)
-            .frame(width: width, height: height, alignment: type.alignment)
-            .padding(type.padding, -height / 5)
-            .clipped()
+        DigitHalfView(digit: text, fontName: fontName, clipTop: type == .top)
+            .frame(width: width, height: height)
             .background(Color.black)
             .cornerRadius(height / 5)
             .padding(type.padding, -height / 10)


### PR DESCRIPTION
## Summary
- correct clipping logic for digit halves and make it reusable
- use the new half digit views inside the clock widget and app
- let large widgets dedicate most of their space to the clock
- drop support for the small widget size

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6852ae9463548326a9ca790c3b469550