### PR TITLE
Fix clock digit scaling

### DIFF
--- a/ClockWeatherApp/DigitHalfView.swift
+++ b/ClockWeatherApp/DigitHalfView.swift
@@ -16,29 +16,14 @@ struct DigitHalfView: View {
     var body: some View {
         GeometryReader { geo in
             let size = geo.size
-            let halfHeight = size.height / 2
+            let textSize = size.height * 2
 
-            ZStack {
-                Text(digit)
-                    .font(.custom(fontName, size: size.height * 1.5))
-                    .frame(width: size.width, height: size.height)
-                    .foregroundStyle(textColor)
-                    .background(backgroundColor)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.1)
-                    .clipped()
-            }
-            .mask(
-                VStack(spacing: 0) {
-                    if clipTop {
-                        Rectangle().frame(height: halfHeight)
-                        Color.clear.frame(height: halfHeight)
-                    } else {
-                        Color.clear.frame(height: halfHeight)
-                        Rectangle().frame(height: halfHeight)
-                    }
-                }
-            )
+            Text(digit)
+                .font(.custom(fontName, size: textSize))
+                .frame(width: size.width, height: textSize, alignment: clipTop ? .top : .bottom)
+                .foregroundStyle(textColor)
+                .background(backgroundColor)
+                .offset(y: clipTop ? 0 : -size.height)
         }
         .clipped()
     }

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -12,27 +12,14 @@ private struct WidgetDigitHalfView: View {
     var body: some View {
         GeometryReader { geo in
             let size = geo.size
-            let half = size.height / 2
+            let textSize = size.height * 2
 
             Text(digit)
-                .font(.custom(fontName, size: size.height * 1.5))
-                .frame(width: size.width, height: size.height)
+                .font(.custom(fontName, size: textSize))
+                .frame(width: size.width, height: textSize, alignment: clipTop ? .top : .bottom)
                 .foregroundStyle(.black)
                 .background(Color.white)
-                .lineLimit(1)
-                .minimumScaleFactor(0.1)
-                .clipped()
-                .mask(
-                    VStack(spacing: 0) {
-                        if clipTop {
-                            Rectangle().frame(height: half)
-                            Color.clear.frame(height: half)
-                        } else {
-                            Color.clear.frame(height: half)
-                            Rectangle().frame(height: half)
-                        }
-                    }
-                )
+                .offset(y: clipTop ? 0 : -size.height)
         }
         .clipped()
     }


### PR DESCRIPTION
## Summary
- fix `DigitHalfView` and `WidgetDigitHalfView` to scale text based on card size
- bottom half now shows the true bottom of the digit

## Testing
- `swift test` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852b1190e808326821a781165e606cd