### PR TITLE
Fix digit rendering and refine card corners

### DIFF
--- a/ClockWeatherApp/DigitHalfView.swift
+++ b/ClockWeatherApp/DigitHalfView.swift
@@ -21,6 +21,7 @@ struct DigitHalfView: View {
             Text(digit)
                 .font(.custom(fontName, size: textSize))
                 .frame(width: size.width, height: textSize, alignment: clipTop ? .top : .bottom)
+                .fixedSize()
                 .foregroundStyle(textColor)
                 .background(backgroundColor)
                 .offset(y: clipTop ? 0 : -size.height)

--- a/ClockWeatherApp/RoundedCorners.swift
+++ b/ClockWeatherApp/RoundedCorners.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import UIKit
+
+struct RoundedCorners: Shape {
+    var radius: CGFloat
+    var corners: UIRectCorner
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect,
+                                byRoundingCorners: corners,
+                                cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/ClockWeatherApp/SingleDigitView.swift
+++ b/ClockWeatherApp/SingleDigitView.swift
@@ -19,7 +19,8 @@ struct SingleDigitView: View {
         DigitHalfView(digit: text, fontName: fontName, clipTop: type == .top)
             .frame(width: width, height: height)
             .background(Color.black)
-            .cornerRadius(height / 5)
+            .clipShape(RoundedCorners(radius: height / 5,
+                                     corners: type == .top ? [.topLeft, .topRight] : [.bottomLeft, .bottomRight]))
             .padding(type.padding, -height / 10)
     }
 

--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -17,6 +17,7 @@ private struct WidgetDigitHalfView: View {
             Text(digit)
                 .font(.custom(fontName, size: textSize))
                 .frame(width: size.width, height: textSize, alignment: clipTop ? .top : .bottom)
+                .fixedSize()
                 .foregroundStyle(.black)
                 .background(Color.white)
                 .offset(y: clipTop ? 0 : -size.height)
@@ -37,7 +38,8 @@ struct WidgetSingleDigitView: View {
         WidgetDigitHalfView(digit: text, fontName: fontName, clipTop: type == .top)
             .frame(width: width, height: height)
             .background(Color.white)
-            .cornerRadius(height / 5)
+            .clipShape(RoundedCorners(radius: height / 5,
+                                     corners: type == .top ? [.topLeft, .topRight] : [.bottomLeft, .bottomRight]))
             .padding(type.padding, -height / 10)
     }
 


### PR DESCRIPTION
## Summary
- ensure text layout in DigitHalfView doesn't clip with certain fonts
- add `RoundedCorners` shape to allow selective corner rounding
- apply new corner rounding logic in digit views and widget

## Testing
- `swift --version`
- `swift test -c debug` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852b2a4e1e08326a6f88dd0991e6ddf