### PR TITLE
Use glass background for widget

### DIFF
--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -282,7 +282,7 @@ struct ClockWeatherWidgetEntryView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 8)
-        .containerBackground(Color.clear, for: .widget)
+        .containerBackground(.ultraThinMaterial, for: .widget)
     }
 
     private var weatherInfo: some View {


### PR DESCRIPTION
## Summary
- set widget background to `.ultraThinMaterial` so it has a glass-like appearance

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bf7f25008326b406c437f667b2c2