### PR TITLE
Improve glass mode digit contrast

### DIFF
--- a/ClockWeatherWidget/ClockWeatherWidget.swift
+++ b/ClockWeatherWidget/ClockWeatherWidget.swift
@@ -25,7 +25,10 @@ private struct WidgetDigitHalfView: View {
         case .fullColor:
             return AnyShapeStyle(Color.white)
         default:
-            return AnyShapeStyle(.ultraThinMaterial)
+            // Use a less transparent material so digits remain
+            // readable when the widget is rendered with the
+            // "glass" appearance.
+            return AnyShapeStyle(.regularMaterial)
         }
     }
 
@@ -60,7 +63,9 @@ struct WidgetSingleDigitView: View {
         case .fullColor:
             return AnyShapeStyle(Color.white)
         default:
-            return AnyShapeStyle(.ultraThinMaterial)
+            // Use a more opaque material to improve contrast in
+            // the widget's "glass" rendering mode.
+            return AnyShapeStyle(.regularMaterial)
         }
     }
 


### PR DESCRIPTION
## Summary
- tweak widget digit background material to improve readability in glass mode

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852cad9e9608326b453239d96bab854